### PR TITLE
feat: allow node configuration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,15 +1,14 @@
 name: 'setup-slurm-action'
 description: 'Setup slurm cluster on GitHub Actions using https://github.com/galaxyproject/ansible-slurm'
 inputs:
-  nodes:
-    description: |
-      List of nodes and their resources to add to the cluster.
-      This needs to be a string that represents a YAML array of YAML objects. 
-      Because indentation is tricky, you are advised to use the YAML flow style with [] and {}
-      delimiters since this style ignores indentation.
+  memory:
+    description: Amount of memory in MB to allocate to this node
     required: true
-    default: >
-      [ { name: localhost, State: UNKNOWN, Sockets: 1, CoresPerSocket: 2, RealMemory: 2000 }
+    default: 2000
+  cpus:
+    description: Number of physical (not virtual) CPUs to allocate to the node
+    required: true
+    default: 1
 branding:
   icon: arrow-down-circle
   color: blue
@@ -63,7 +62,12 @@ runs:
                     StoragePort: 8888
                     DbdHost: localhost
                 slurm_create_user: yes
-                slurm_nodes: ${{ inputs.nodes }}
+                slurm_nodes:
+                    - name: localhost
+                      State: UNKNOWN
+                      Sockets: ${{ input.cpus }}
+                      CoresPerSocket: 2
+                      RealMemory: ${{ input.memory }}
                 slurm_user:
                     comment: "Slurm Workload Manager"
                     gid: 1002

--- a/action.yml
+++ b/action.yml
@@ -65,9 +65,9 @@ runs:
                 slurm_nodes:
                     - name: localhost
                       State: UNKNOWN
-                      Sockets: ${{ input.cpus }}
+                      Sockets: ${{ inputs.cpus }}
                       CoresPerSocket: 2
-                      RealMemory: ${{ input.memory }}
+                      RealMemory: ${{ inputs.memory }}
                 slurm_user:
                     comment: "Slurm Workload Manager"
                     gid: 1002

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,17 @@
 name: 'setup-slurm-action'
 description: 'Setup slurm cluster on GitHub Actions using https://github.com/galaxyproject/ansible-slurm'
+inputs:
+  nodes:
+    description: |
+      List of nodes and their resources to add to the cluster.
+      Note that this is a string field that needs to contain a YAML array with exactly 20 spaces of indentation, or it won't interpolate correctly
+    required: true
+    default: |
+                    - name: localhost
+                      State: UNKNOWN
+                      Sockets: 1
+                      CoresPerSocket: 2
+                      RealMemory: 2000
 branding:
   icon: arrow-down-circle
   color: blue
@@ -53,13 +65,8 @@ runs:
                     StoragePort: 8888
                     DbdHost: localhost
                 slurm_create_user: yes
-                #slurm_munge_key: "../../../munge.key"
                 slurm_nodes:
-                    - name: localhost
-                      State: UNKNOWN
-                      Sockets: 1
-                      CoresPerSocket: 2
-                      RealMemory: 2000
+                    ${{ inputs.nodes }}
                 slurm_user:
                     comment: "Slurm Workload Manager"
                     gid: 1002

--- a/action.yml
+++ b/action.yml
@@ -4,14 +4,12 @@ inputs:
   nodes:
     description: |
       List of nodes and their resources to add to the cluster.
-      Note that this is a string field that needs to contain a YAML array with exactly 20 spaces of indentation, or it won't interpolate correctly
+      This needs to be a string that represents a YAML array of YAML objects. 
+      Because indentation is tricky, you are advised to use the YAML flow style with [] and {}
+      delimiters since this style ignores indentation.
     required: true
-    default: |
-                    - name: localhost
-                      State: UNKNOWN
-                      Sockets: 1
-                      CoresPerSocket: 2
-                      RealMemory: 2000
+    default: >
+      [ { name: localhost, State: UNKNOWN, Sockets: 1, CoresPerSocket: 2, RealMemory: 2000 }
 branding:
   icon: arrow-down-circle
   color: blue
@@ -65,8 +63,7 @@ runs:
                     StoragePort: 8888
                     DbdHost: localhost
                 slurm_create_user: yes
-                slurm_nodes:
-                    ${{ inputs.nodes }}
+                slurm_nodes: ${{ inputs.nodes }}
                 slurm_user:
                     comment: "Slurm Workload Manager"
                     gid: 1002


### PR DESCRIPTION
Currently the cluster is hardcoded to have one node with 2000 MB RAM. Some users might want to configure this. In particular, the free GitHub runner 16 GB of RAM, so it's possible to allocate more memory to these nodes.

I tried to allow for multi-node configuration but I think this is difficult because it would require some extra containers in order to give each node a separate hostname. So my quick fix was just to add a `memory` and `cpus` input that let you configure the specs of the one node in the cluster.

Here is an example run using my fork of this action: https://github.com/multimeric/SlurmActionTest/actions/runs/12345117113/job/34448676056
You can see how the memory is reported as 3 GB and so is working correctly.