### PR TITLE
fix: Limit sacctmgr retries to 2 mins

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,8 +83,8 @@ runs:
     - name: Add Slurm Account
       shell: bash -e {0}
       run: |
-        sudo retry --until=success -- sacctmgr -i create account "Name=runner"
-        sudo retry --until=success -- sacctmgr -i create user "Name=runner" "Account=runner"
+        sudo retry --times=24 --delay=5 --until=success -- sacctmgr -i create account "Name=runner"
+        sudo retry --times=24 --delay=5 --until=success -- sacctmgr -i create user "Name=runner" "Account=runner"
 
     - name: Test srun submission
       shell: bash -e {0}


### PR DESCRIPTION
On rare occasion, this job will run forever (or at least many many hours until it gets shut down by GitHub):

```
Run sudo retry --until=success -- sacctmgr -i create account "Name=runner"
 Adding Account(s)
  runner
 Settings
  Description     = Account Name
  Organization    = Parent/Account Name
No account runner on cluster cluster, skipping.
Nothing added.
Make sure the accounts requested here have been added to the system/cluster. (sacctmgr add account...)
retry: sacctmgr returned 1, backing off for 10 seconds and trying again...
No account runner on cluster cluster, skipping.
Nothing added.
Make sure the accounts requested here have been added to the system/cluster. (sacctmgr add account...)
retry: sacctmgr returned 1, backing off for 10 seconds and trying again...
No account runner on cluster cluster, skipping.
Nothing added.
Make sure the accounts requested here have been added to the system/cluster. (sacctmgr add account...)
retry: sacctmgr returned 1, backing off for 10 seconds and trying again...
No account runner on cluster cluster, skipping.
Nothing added.
Make sure the accounts requested here have been added to the system/cluster. (sacctmgr add account...)
retry: sacctmgr returned 1, backing off for 10 seconds and trying again...
No account runner on cluster cluster, skipping.
Nothing added.
```

This will limit it to 2 mins of retries (24 retries at 5 secs each).